### PR TITLE
Implement MarketDataFetcher with caching and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cache/
+__pycache__/
+*.pyc

--- a/UnitTests/test_market_data_fetcher.py
+++ b/UnitTests/test_market_data_fetcher.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from unittest.mock import patch
+import pandas as pd
+from market_data_fetcher import MarketDataFetcher
+
+
+class TestMarketDataAdapter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fetcher = MarketDataFetcher(cache_dir="test_cache")
+        os.makedirs("test_cache", exist_ok=True)
+
+    def tearDown(self) -> None:
+        for f in os.listdir("test_cache"):
+            os.remove(os.path.join("test_cache", f))
+        os.rmdir("test_cache")
+
+    @patch("yfinance.download")
+    def test_successful_fetch(self, mock_download):
+        index = pd.date_range("2020-01-01", periods=2)
+        df = pd.DataFrame({"Adj Close": [10.0, 12.0]}, index=index)
+        mock_download.return_value = df
+        data = self.fetcher.MarketDataAdapter(["AAPL"])
+        self.assertIn("AAPL", data.columns)
+        self.assertEqual(len(data), 2)
+
+    @patch("yfinance.download")
+    def test_failure_fetch(self, mock_download):
+        mock_download.return_value = pd.DataFrame()
+        with self.assertRaises(RuntimeError):
+            self.fetcher.MarketDataAdapter(["INVALID"]) 
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+from market_data_fetcher import MarketDataFetcher
+
+
+def main() -> None:
+    tickers = ["AAPL", "MSFT"]
+    fetcher = MarketDataFetcher()
+    try:
+        data = fetcher.MarketDataAdapter(tickers)
+        print(data.tail())
+    except Exception as exc:
+        print(f"Failed to fetch data: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/market_data_fetcher.py
+++ b/market_data_fetcher.py
@@ -1,0 +1,54 @@
+import os
+from typing import List, Optional
+import pandas as pd
+import yfinance as yf
+
+
+class MarketDataFetcher:
+    """Fetches and caches market data."""
+
+    def __init__(self, cache_dir: str = "cache") -> None:
+        self.cache_dir = cache_dir
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+    def MarketDataCache(self, ticker: str, data: Optional[pd.DataFrame] = None) -> Optional[pd.DataFrame]:
+        """Save or load data for a ticker from cache."""
+        path = os.path.join(self.cache_dir, f"{ticker}.csv")
+        if data is None:
+            if os.path.exists(path):
+                return pd.read_csv(path, index_col=0, parse_dates=True)
+            return None
+        data.to_csv(path)
+        return data
+
+    def MarketDataAdapter(self, tickers: List[str]) -> pd.DataFrame:
+        """Pull adjusted close prices for tickers."""
+        frames = []
+        failures = []
+        for ticker in tickers:
+            df = self.MarketDataCache(ticker)
+            if df is None:
+                try:
+                    raw = yf.download(ticker, progress=False, auto_adjust=False)
+                except Exception as exc:
+                    failures.append((ticker, str(exc)))
+                    continue
+                if raw.empty:
+                    failures.append((ticker, "empty data"))
+                    continue
+                if isinstance(raw.columns, pd.MultiIndex):
+                    adj = raw[("Adj Close", ticker)]
+                else:
+                    adj = raw["Adj Close"]
+                df = adj.to_frame(name=ticker)
+                self.MarketDataCache(ticker, df)
+            frames.append(df.rename(columns={df.columns[0]: ticker}))
+        if failures:
+            raise RuntimeError(f"Failed to retrieve data for: {failures}")
+        return self.MarketDataParser(frames)
+
+    def MarketDataParser(self, frames: List[pd.DataFrame]) -> pd.DataFrame:
+        """Parse and combine API responses into a single DataFrame."""
+        if not frames:
+            raise ValueError("No data to parse")
+        return pd.concat(frames, axis=1).sort_index()


### PR DESCRIPTION
## Summary
- implement `MarketDataFetcher` with adapter, parser and cache features
- add command-line usage in `main.py`
- add unit tests for market data adapter
- ignore cache folder in git

## Testing
- `python -m pytest -q`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_684c4c7dda28832098ede8ef6358b39b