### PR TITLE
Implement momentum ranking engine

### DIFF
--- a/MomentumEngine.py
+++ b/MomentumEngine.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from typing import List, Union
+
+
+class MomentumEngine:
+    """Calculate momentum scores and ranks."""
+
+    def LookbackWindowValidator(self, lookbacks: Union[int, List[int]]) -> List[int]:
+        """Validate user look-back periods and return a sorted unique list."""
+        if isinstance(lookbacks, int):
+            lookbacks = [lookbacks]
+        elif isinstance(lookbacks, (list, tuple, set)):
+            lookbacks = list(lookbacks)
+        else:
+            raise TypeError("lookbacks must be an int or list of ints")
+        validated = []
+        for lb in lookbacks:
+            try:
+                lb_int = int(lb)
+            except Exception as exc:  # noqa: BLE001
+                raise ValueError(f"invalid lookback: {lb}") from exc
+            if lb_int <= 0:
+                raise ValueError("lookback periods must be positive")
+            validated.append(lb_int)
+        return sorted(set(validated))
+
+    def CumulativeReturnCalculator(self, data: pd.DataFrame, lookbacks: Union[int, List[int]]) -> pd.DataFrame:
+        """Compute cumulative percent returns for each look-back period."""
+        windows = self.LookbackWindowValidator(lookbacks)
+        returns = pd.DataFrame(index=data.columns)
+        for window in windows:
+            ret = data.pct_change(periods=window).iloc[-1] * 100
+            returns[f"Lookback_{window}"] = ret
+        return returns
+
+    def MomentumRanker(self, data: pd.DataFrame, lookbacks: Union[int, List[int]]) -> pd.DataFrame:
+        """Rank tickers by momentum for each look-back window."""
+        returns = self.CumulativeReturnCalculator(data, lookbacks)
+        ranks = pd.DataFrame(index=returns.index)
+        for column in returns.columns:
+            sorted_series = returns[column].sort_values(ascending=False)
+            rank = range(1, len(sorted_series) + 1)
+            ranks[column] = pd.Series(rank, index=sorted_series.index)
+        return ranks.reindex(returns.index)

--- a/UnitTests/test_momentum_engine.py
+++ b/UnitTests/test_momentum_engine.py
@@ -1,0 +1,31 @@
+import unittest
+import pandas as pd
+from MomentumEngine import MomentumEngine
+
+
+class TestMomentumRanker(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = MomentumEngine()
+        data = pd.DataFrame({
+            'AAA': [1, 2, 3, 4, 5, 6],
+            'BBB': [1, 1, 1, 1, 1, 1],
+            'CCC': [5, 4, 3, 2, 1, 0.5],
+        }, index=pd.date_range('2020-01-01', periods=6))
+        self.data = data
+
+    def test_cumulative_return_calculator(self):
+        returns = self.engine.CumulativeReturnCalculator(self.data, [1, 5])
+        expected_1 = (self.data.iloc[-1] / self.data.iloc[-2] - 1) * 100
+        expected_5 = (self.data.iloc[-1] / self.data.iloc[0] - 1) * 100
+        self.assertAlmostEqual(returns.loc['AAA', 'Lookback_1'], expected_1['AAA'])
+        self.assertAlmostEqual(returns.loc['AAA', 'Lookback_5'], expected_5['AAA'])
+
+    def test_momentum_ranker(self):
+        ranks = self.engine.MomentumRanker(self.data, [5])
+        self.assertEqual(ranks.loc['AAA', 'Lookback_5'], 1)
+        self.assertEqual(ranks.loc['BBB', 'Lookback_5'], 2)
+        self.assertEqual(ranks.loc['CCC', 'Lookback_5'], 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from MarketDataFetcher import MarketDataFetcher
 from IndicatorEngine import IndicatorEngine
 from IndicatorNormalizer import IndicatorNormalizer
+from MomentumEngine import MomentumEngine
 import pandas as pd
 
 
@@ -9,6 +10,7 @@ def main() -> None:
     fetcher = MarketDataFetcher()
     engine = IndicatorEngine()
     normalizer = IndicatorNormalizer()
+    momentum = MomentumEngine()
     try:
         data = fetcher.MarketDataAdapter(tickers)
         rows = []
@@ -24,6 +26,8 @@ def main() -> None:
         df_clean = normalizer.MissingValueHandler(df, method="ffill")
         df_norm = normalizer.ZScoreNormalizer(df_clean)
         print(df_norm)
+        ranks = momentum.MomentumRanker(data, [5])
+        print(ranks)
     except Exception as exc:
         print(f"Failed to fetch data: {exc}")
 


### PR DESCRIPTION
## Summary
- add MomentumEngine with helper functions to compute momentum ranks
- unit tests for momentum ranking
- use MomentumEngine in main demo

## Testing
- `python -m unittest discover -s UnitTests`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_684c548f667483209e9c93f083576652