### PR TITLE
Implement scoring engine with aggregation and tests

### DIFF
--- a/ScoringEngine.py
+++ b/ScoringEngine.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from typing import Dict, Optional
+
+
+class ScoringEngine:
+    """Aggregate indicator and momentum scores."""
+
+    def IndicatorWeighter(self, normalized: pd.DataFrame, weights: Optional[Dict[str, float]] = None) -> pd.Series:
+        """Weight normalized indicators based on provided weights."""
+        if weights is None:
+            weights = {col: 1.0 for col in normalized.columns}
+        for key in weights:
+            if key not in normalized.columns:
+                raise KeyError(f"Unknown indicator: {key}")
+        weight_series = pd.Series(weights)
+        aligned = normalized.reindex(columns=weight_series.index)
+        weighted = aligned.mul(weight_series, axis=1)
+        return weighted.sum(axis=1)
+
+    def ScoreAggregator(self, weighted_scores: pd.Series, momentum_ranks: pd.Series, momentum_weight: float = 1.0) -> pd.Series:
+        """Combine weighted indicator scores with momentum rank scores."""
+        if not weighted_scores.index.equals(momentum_ranks.index):
+            momentum_ranks = momentum_ranks.reindex(weighted_scores.index)
+        momentum_component = -momentum_ranks * momentum_weight
+        return weighted_scores + momentum_component
+
+    def ScoreScaler(self, scores: pd.Series) -> pd.Series:
+        """Scale composite scores to a 0-100 range."""
+        min_score = scores.min()
+        max_score = scores.max()
+        if max_score == min_score:
+            return pd.Series(50.0, index=scores.index)
+        return (scores - min_score) / (max_score - min_score) * 100
+
+    def TestScoreAggregation(self) -> bool:
+        """Ensure scoring is deterministic."""
+        df_norm = pd.DataFrame({
+            "IndA": [0.0, 1.0],
+            "IndB": [1.0, 0.0],
+        }, index=["A", "B"])
+        weights = {"IndA": 2.0, "IndB": 1.0}
+        momentum = pd.Series({"A": 1, "B": 2})
+        first = self.ScoreScaler(
+            self.ScoreAggregator(
+                self.IndicatorWeighter(df_norm, weights), momentum, momentum_weight=0.5
+            )
+        )
+        second = self.ScoreScaler(
+            self.ScoreAggregator(
+                self.IndicatorWeighter(df_norm, weights), momentum, momentum_weight=0.5
+            )
+        )
+        pd.testing.assert_series_equal(first, second)
+        return True

--- a/UnitTests/test_scoring_engine.py
+++ b/UnitTests/test_scoring_engine.py
@@ -1,0 +1,38 @@
+import unittest
+import pandas as pd
+from ScoringEngine import ScoringEngine
+
+
+class TestScoringEngine(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = ScoringEngine()
+        self.df_norm = pd.DataFrame({
+            "IndA": [0.0, 1.0],
+            "IndB": [1.0, 0.0],
+        }, index=["A", "B"])
+        self.weights = {"IndA": 2.0, "IndB": 1.0}
+        self.momentum = pd.Series({"A": 1, "B": 2})
+
+    def test_indicator_weighter(self):
+        weighted = self.engine.IndicatorWeighter(self.df_norm, self.weights)
+        self.assertAlmostEqual(weighted.loc["A"], 1.0)
+        self.assertAlmostEqual(weighted.loc["B"], 2.0)
+
+    def test_score_aggregator(self):
+        weighted = self.engine.IndicatorWeighter(self.df_norm, self.weights)
+        combined = self.engine.ScoreAggregator(weighted, self.momentum, momentum_weight=0.5)
+        self.assertAlmostEqual(combined.loc["A"], weighted.loc["A"] - 0.5)
+        self.assertAlmostEqual(combined.loc["B"], weighted.loc["B"] - 1.0)
+
+    def test_score_scaler(self):
+        series = pd.Series([1.0, 3.0], index=["A", "B"])
+        scaled = self.engine.ScoreScaler(series)
+        self.assertAlmostEqual(scaled.loc["A"], 0.0)
+        self.assertAlmostEqual(scaled.loc["B"], 100.0)
+
+    def test_test_score_aggregation(self):
+        self.assertTrue(self.engine.TestScoreAggregation())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from MarketDataFetcher import MarketDataFetcher
 from IndicatorEngine import IndicatorEngine
 from IndicatorNormalizer import IndicatorNormalizer
 from MomentumEngine import MomentumEngine
+from ScoringEngine import ScoringEngine
 import pandas as pd
 
 
@@ -11,6 +12,7 @@ def main() -> None:
     engine = IndicatorEngine()
     normalizer = IndicatorNormalizer()
     momentum = MomentumEngine()
+    scorer = ScoringEngine()
     try:
         data = fetcher.MarketDataAdapter(tickers)
         rows = []
@@ -28,6 +30,12 @@ def main() -> None:
         print(df_norm)
         ranks = momentum.MomentumRanker(data, [5])
         print(ranks)
+
+        weights = {"SMA": 1.0, "EMA": 1.0, "RSI": 1.0, "Volatility": 1.0}
+        weighted = scorer.IndicatorWeighter(df_norm, weights)
+        combined = scorer.ScoreAggregator(weighted, ranks["Lookback_5"], momentum_weight=1.0)
+        scaled = scorer.ScoreScaler(combined)
+        print(scaled)
     except Exception as exc:
         print(f"Failed to fetch data: {exc}")
 


### PR DESCRIPTION
## Summary
- implement `ScoringEngine` with indicator weighting, aggregation, scaling and deterministic test
- add unit tests for the scoring engine
- integrate scoring engine usage in `main.py`

## Testing
- `python -m pytest -q`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_684c565c0cac832098ae00e27a97bf86