### PR TITLE
Add PortfolioEngine portfolio management features

### DIFF
--- a/PortfolioEngine.py
+++ b/PortfolioEngine.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from typing import Optional
+
+
+class PortfolioEngine:
+    """Construct portfolios based on composite scores."""
+
+    def PortfolioSelector(self, scores: pd.Series, top_n: int) -> pd.Series:
+        """Return the top N tickers sorted by composite score."""
+        if top_n <= 0:
+            raise ValueError("top_n must be positive")
+        if scores.empty:
+            raise ValueError("No scores provided")
+        sorted_scores = scores.sort_values(ascending=False).dropna()
+        return sorted_scores.head(top_n)
+
+    def AllocationCalculator(self, selected: pd.Series, method: str = "equal") -> pd.Series:
+        """Calculate allocations for selected tickers."""
+        if selected.empty:
+            raise ValueError("No tickers selected")
+        if method not in ("equal", "score"):
+            raise ValueError("Unknown allocation method")
+        if method == "equal":
+            weight = 1.0 / len(selected)
+            return pd.Series(weight, index=selected.index)
+        total = selected.sum()
+        if total == 0:
+            return pd.Series(1.0 / len(selected), index=selected.index)
+        return selected / total
+
+    def PortfolioExporter(self, selected: pd.Series, allocations: pd.Series, csv_path: str, json_path: str) -> pd.DataFrame:
+        """Export portfolio selections to CSV and JSON files."""
+        df = pd.DataFrame({"Score": selected, "Allocation": allocations})
+        df.to_csv(csv_path)
+        df.to_json(json_path, orient="records")
+        return df
+
+    def TestPortfolioSelector(self) -> bool:
+        """Validate portfolio selection logic."""
+        scores = pd.Series({"AAA": 3.0, "BBB": 1.0, "CCC": 2.0})
+        top = self.PortfolioSelector(scores, 2)
+        assert list(top.index) == ["AAA", "CCC"]
+        alloc_equal = self.AllocationCalculator(top, method="equal")
+        alloc_score = self.AllocationCalculator(top, method="score")
+        assert abs(alloc_equal.sum() - 1.0) < 1e-8
+        assert abs(alloc_score.sum() - 1.0) < 1e-8
+        return True

--- a/UnitTests/test_portfolio_engine.py
+++ b/UnitTests/test_portfolio_engine.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+import pandas as pd
+from PortfolioEngine import PortfolioEngine
+
+
+class TestPortfolioEngine(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = PortfolioEngine()
+        self.scores = pd.Series({"AAA": 3.0, "BBB": 1.0, "CCC": 2.0})
+
+    def test_portfolio_selector(self):
+        result = self.engine.PortfolioSelector(self.scores, 2)
+        self.assertListEqual(list(result.index), ["AAA", "CCC"])
+
+    def test_allocation_calculator_equal(self):
+        selected = self.engine.PortfolioSelector(self.scores, 2)
+        alloc = self.engine.AllocationCalculator(selected, method="equal")
+        self.assertAlmostEqual(alloc.sum(), 1.0)
+        self.assertTrue((alloc == 0.5).all())
+
+    def test_allocation_calculator_score(self):
+        selected = self.engine.PortfolioSelector(self.scores, 2)
+        alloc = self.engine.AllocationCalculator(selected, method="score")
+        self.assertAlmostEqual(alloc.sum(), 1.0)
+        expected = selected / selected.sum()
+        pd.testing.assert_series_equal(alloc, expected)
+
+    def test_portfolio_exporter(self):
+        selected = self.engine.PortfolioSelector(self.scores, 2)
+        alloc = self.engine.AllocationCalculator(selected)
+        self.engine.PortfolioExporter(selected, alloc, "test_port.csv", "test_port.json")
+        self.assertTrue(os.path.exists("test_port.csv"))
+        self.assertTrue(os.path.exists("test_port.json"))
+        os.remove("test_port.csv")
+        os.remove("test_port.json")
+
+    def test_test_portfolio_selector(self):
+        self.assertTrue(self.engine.TestPortfolioSelector())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from IndicatorEngine import IndicatorEngine
 from IndicatorNormalizer import IndicatorNormalizer
 from MomentumEngine import MomentumEngine
 from ScoringEngine import ScoringEngine
+from PortfolioEngine import PortfolioEngine
 import pandas as pd
 
 
@@ -13,6 +14,7 @@ def main() -> None:
     normalizer = IndicatorNormalizer()
     momentum = MomentumEngine()
     scorer = ScoringEngine()
+    portfolio = PortfolioEngine()
     try:
         data = fetcher.MarketDataAdapter(tickers)
         rows = []
@@ -36,6 +38,12 @@ def main() -> None:
         combined = scorer.ScoreAggregator(weighted, ranks["Lookback_5"], momentum_weight=1.0)
         scaled = scorer.ScoreScaler(combined)
         print(scaled)
+
+        top = portfolio.PortfolioSelector(scaled, 2)
+        alloc = portfolio.AllocationCalculator(top, method="equal")
+        portfolio.PortfolioExporter(top, alloc, "portfolio.csv", "portfolio.json")
+        print(top)
+        print(alloc)
     except Exception as exc:
         print(f"Failed to fetch data: {exc}")
 


### PR DESCRIPTION
## Summary
- add new `PortfolioEngine` module for selecting tickers and calculating allocations
- export portfolio selections to CSV and JSON
- create comprehensive tests for portfolio engine
- integrate portfolio generation into `main.py`