### PR TITLE
Implement lookback weights usage in main

### DIFF
--- a/UnitTests/test_momentum_engine.py
+++ b/UnitTests/test_momentum_engine.py
@@ -26,6 +26,13 @@ class TestMomentumRanker(unittest.TestCase):
         self.assertEqual(ranks.loc['BBB', 'Lookback_5'], 2)
         self.assertEqual(ranks.loc['CCC', 'Lookback_5'], 3)
 
+    def test_momentum_ranker_multiple(self):
+        ranks = self.engine.MomentumRanker(self.data, [1, 5])
+        self.assertIn('Lookback_1', ranks.columns)
+        self.assertIn('Lookback_5', ranks.columns)
+        self.assertEqual(ranks.loc['AAA', 'Lookback_1'], 1)
+        self.assertEqual(ranks.loc['BBB', 'Lookback_1'], 2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/UnitTests/test_scoring_engine.py
+++ b/UnitTests/test_scoring_engine.py
@@ -12,6 +12,10 @@ class TestScoringEngine(unittest.TestCase):
         }, index=["A", "B"])
         self.weights = {"IndA": 2.0, "IndB": 1.0}
         self.momentum = pd.Series({"A": 1, "B": 2})
+        self.momentum_df = pd.DataFrame({
+            "Lookback_5": [1, 2],
+            "Lookback_10": [1, 2],
+        }, index=["A", "B"])
 
     def test_indicator_weighter(self):
         weighted = self.engine.IndicatorWeighter(self.df_norm, self.weights)
@@ -23,6 +27,32 @@ class TestScoringEngine(unittest.TestCase):
         combined = self.engine.ScoreAggregator(weighted, self.momentum, momentum_weight=0.5)
         self.assertAlmostEqual(combined.loc["A"], weighted.loc["A"] - 0.5)
         self.assertAlmostEqual(combined.loc["B"], weighted.loc["B"] - 1.0)
+
+    def test_momentum_weighter(self):
+        agg = self.engine.MomentumWeighter(self.momentum_df)
+        self.assertAlmostEqual(agg.loc["A"], 1.0)
+        self.assertAlmostEqual(agg.loc["B"], 2.0)
+
+    def test_score_aggregator_dataframe(self):
+        weighted = self.engine.IndicatorWeighter(self.df_norm, self.weights)
+        combined = self.engine.ScoreAggregator(weighted, self.momentum_df, momentum_weight=0.5)
+        expected = weighted - self.engine.MomentumWeighter(self.momentum_df) * 0.5
+        pd.testing.assert_series_equal(combined, expected)
+
+    def test_score_aggregator_with_weights(self):
+        weighted = self.engine.IndicatorWeighter(self.df_norm, self.weights)
+        LookbackWeights = {"Lookback_5": 0.3, "Lookback_10": 0.7}
+        combined = self.engine.ScoreAggregator(
+            weighted,
+            self.momentum_df,
+            momentum_weight=1.0,
+            lookback_weights=LookbackWeights,
+        )
+        expected = weighted - self.engine.MomentumWeighter(
+            self.momentum_df,
+            LookbackWeights,
+        )
+        pd.testing.assert_series_equal(combined, expected)
 
     def test_score_scaler(self):
         series = pd.Series([1.0, 3.0], index=["A", "B"])

--- a/main.py
+++ b/main.py
@@ -30,12 +30,19 @@ def main() -> None:
         df_clean = normalizer.MissingValueHandler(df, method="ffill")
         df_norm = normalizer.ZScoreNormalizer(df_clean)
         print(df_norm)
-        ranks = momentum.MomentumRanker(data, [5])
+        lookbacks = [5, 10, 20, 30, 40, 50]
+        ranks = momentum.MomentumRanker(data, lookbacks)
+        LookbackWeights = {f"Lookback_{lb}": 1.0 for lb in lookbacks}
         print(ranks)
 
         weights = {"SMA": 1.0, "EMA": 1.0, "RSI": 1.0, "Volatility": 1.0}
         weighted = scorer.IndicatorWeighter(df_norm, weights)
-        combined = scorer.ScoreAggregator(weighted, ranks["Lookback_5"], momentum_weight=1.0)
+        combined = scorer.ScoreAggregator(
+            weighted,
+            ranks,
+            momentum_weight=1.0,
+            lookback_weights=LookbackWeights,
+        )
         scaled = scorer.ScoreScaler(combined)
         print(scaled)
 


### PR DESCRIPTION
## Summary
- integrate lookback weights in `main.py`
- verify custom lookback weighting in scoring unit tests

## Testing
- `pytest -q`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_684cbf828ce083209adb6a2bbff41b52