### PR TITLE
Add backtesting engine with buy-and-hold strategy

### DIFF
--- a/BacktestingEngine.py
+++ b/BacktestingEngine.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from typing import List
+from backtesting import Backtest, Strategy
+from MarketDataFetcher import MarketDataFetcher
+from PortfolioEngine import PortfolioEngine
+
+
+class BuyAndHoldStrategy(Strategy):
+    """Simple buy-and-hold strategy."""
+
+    def init(self) -> None:  # noqa: D401
+        """Buy at the first available bar."""
+        self.buy()
+
+    def next(self) -> None:  # noqa: D401
+        """No-op for each bar."""
+        pass
+
+
+class BacktestingEngine:
+    """Backtest a portfolio of tickers using backtesting.py."""
+
+    def __init__(self, fetcher: MarketDataFetcher | None = None) -> None:
+        self.fetcher = fetcher or MarketDataFetcher()
+        self.portfolio = PortfolioEngine()
+
+    def AllocationFromHistory(self, tickers: List[str]) -> pd.Series:
+        """Calculate allocations based on 2020-2023 performance."""
+        data = self.fetcher.MarketDataAdapter(tickers)
+        history = data.loc["2020-01-01":"2023-12-31"]
+        cumulative = history.pct_change().add(1).prod() - 1
+        top_count = max(int(len(tickers) * 0.3), 1)
+        selected = cumulative.sort_values(ascending=False).head(top_count)
+        return self.portfolio.AllocationCalculator(selected, method="score")
+
+    def PortfolioBacktest(self, allocations: pd.Series) -> float:
+        """Run backtest for 2024 based on predetermined allocations."""
+        results = []
+        for ticker, weight in allocations.items():
+            data = self.fetcher.MarketDataAdapter([ticker])
+            trade_data = data.loc["2024-01-01":"2024-12-31"]
+            if trade_data.empty:
+                continue
+            df = pd.DataFrame(
+                {
+                    "Open": trade_data[ticker],
+                    "High": trade_data[ticker],
+                    "Low": trade_data[ticker],
+                    "Close": trade_data[ticker],
+                }
+            )
+            initial_cash = 10000 * weight
+            backtest = Backtest(df, BuyAndHoldStrategy, cash=initial_cash, trade_on_close=True)
+            stats = backtest.run()
+            ret = stats["Equity Final [$]"] / initial_cash - 1
+            results.append(ret * weight)
+        if results:
+            return sum(results)
+        return 0.0

--- a/UnitTests/test_backtesting_engine.py
+++ b/UnitTests/test_backtesting_engine.py
@@ -1,0 +1,37 @@
+import unittest
+import pandas as pd
+from unittest.mock import patch
+from BacktestingEngine import BacktestingEngine
+from MarketDataFetcher import MarketDataFetcher
+
+
+class TestBacktestingEngine(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fetcher = MarketDataFetcher()
+        self.engine = BacktestingEngine(self.fetcher)
+        dates_train = pd.date_range("2020-01-01", periods=4, freq="D")
+        dates_test = pd.date_range("2024-01-01", periods=3, freq="D")
+        all_dates = dates_train.append(dates_test)
+        self.data = pd.DataFrame(
+            {
+                "AAA": [1, 2, 3, 4, 4, 5, 6],
+                "BBB": [1, 1, 1, 1, 1, 1, 1],
+                "CCC": [4, 3, 2, 1, 1, 0.8, 0.6],
+            },
+            index=all_dates,
+        )
+
+    def fake_adapter(self, tickers):
+        return self.data[tickers]
+
+    @patch.object(MarketDataFetcher, "MarketDataAdapter")
+    def test_allocation_and_backtest(self, mock_adapter):
+        mock_adapter.side_effect = self.fake_adapter
+        alloc = self.engine.AllocationFromHistory(["AAA", "BBB", "CCC"])
+        self.assertListEqual(list(alloc.index), ["AAA"])
+        result = self.engine.PortfolioBacktest(alloc)
+        self.assertGreater(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from IndicatorNormalizer import IndicatorNormalizer
 from MomentumEngine import MomentumEngine
 from ScoringEngine import ScoringEngine
 from PortfolioEngine import PortfolioEngine
+from BacktestingEngine import BacktestingEngine
 from ConfigManager import ConfigManager
 import pandas as pd
 
@@ -71,6 +72,11 @@ def main() -> None:
         )
         print(top)
         print(alloc)
+
+        backtester = BacktestingEngine(fetcher)
+        hist_alloc = backtester.AllocationFromHistory(tickers)
+        backtest_return = backtester.PortfolioBacktest(hist_alloc)
+        print(f"Backtest return: {backtest_return:.2%}")
     except Exception as exc:
         print(f"Failed to fetch data: {exc}")
 


### PR DESCRIPTION
## Summary
- create `BacktestingEngine` using backtesting.py to compute allocations from history and run a buy-and-hold backtest
- integrate engine into `main.py`
- add unit tests for new engine