### PR TITLE
Add periodic rebalancing backtest

### DIFF
--- a/BacktestingEngine.py
+++ b/BacktestingEngine.py
@@ -33,6 +33,15 @@ class BacktestingEngine:
         selected = cumulative.sort_values(ascending=False).head(top_count)
         return self.portfolio.AllocationCalculator(selected, method="score")
 
+    def AllocationUntilDate(self, tickers: List[str], end_date: str) -> pd.Series:
+        """Calculate allocations using data up to a given end date."""
+        data = self.fetcher.MarketDataAdapter(tickers)
+        history = data.loc["2020-01-01":end_date]
+        cumulative = history.pct_change().add(1).prod() - 1
+        top_count = max(int(len(tickers) * 0.3), 1)
+        selected = cumulative.sort_values(ascending=False).head(top_count)
+        return self.portfolio.AllocationCalculator(selected, method="score")
+
     def PortfolioBacktest(self, allocations: pd.Series) -> float:
         """Run backtest for 2024 based on predetermined allocations."""
         results = []
@@ -65,3 +74,40 @@ class BacktestingEngine:
         weight = 1.0 / len(tickers)
         allocations = pd.Series(weight, index=tickers)
         return self.PortfolioBacktest(allocations)
+
+    def IntervalBacktest(self, tickers: List[str], months: int) -> float:
+        """Backtest with periodic rebalancing using a month interval."""
+        if months <= 0:
+            raise ValueError("months must be positive")
+
+        start_date = pd.Timestamp("2024-01-01")
+        end_date = pd.Timestamp("2024-12-31")
+        current = start_date
+        portfolio_value = 1.0
+
+        while current <= end_date:
+            lookback_end = (current - pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+            allocations = self.AllocationUntilDate(tickers, lookback_end)
+
+            period_end = current + pd.DateOffset(months=months) - pd.Timedelta(days=1)
+            if period_end > end_date:
+                period_end = end_date
+
+            period_returns = []
+            for ticker, weight in allocations.items():
+                data = self.fetcher.MarketDataAdapter([ticker])
+                trade = data.loc[current:period_end]
+                if trade.empty:
+                    continue
+                start_price = trade[ticker].iloc[0]
+                end_price = trade[ticker].iloc[-1]
+                ret = end_price / start_price - 1
+                period_returns.append(ret * weight)
+
+            if period_returns:
+                period_total = sum(period_returns)
+                portfolio_value *= 1 + period_total
+
+            current = period_end + pd.Timedelta(days=1)
+
+        return portfolio_value - 1

--- a/Parameters.yaml
+++ b/Parameters.yaml
@@ -29,3 +29,4 @@ TopN: 2
 AllocationMethod: equal
 CsvPath: portfolio.csv
 JsonPath: portfolio.json
+RebalanceIntervalMonths: 3

--- a/UnitTests/test_backtesting_engine.py
+++ b/UnitTests/test_backtesting_engine.py
@@ -10,13 +10,13 @@ class TestBacktestingEngine(unittest.TestCase):
         self.fetcher = MarketDataFetcher()
         self.engine = BacktestingEngine(self.fetcher)
         dates_train = pd.date_range("2020-01-01", periods=4, freq="D")
-        dates_test = pd.date_range("2024-01-01", periods=3, freq="D")
+        dates_test = pd.date_range("2024-01-01", periods=90, freq="D")
         all_dates = dates_train.append(dates_test)
         self.data = pd.DataFrame(
             {
-                "AAA": [1, 2, 3, 4, 4, 5, 6],
-                "BBB": [1, 1, 1, 1, 1, 1, 1],
-                "CCC": [4, 3, 2, 1, 1, 0.8, 0.6],
+                "AAA": list(range(1, 95)),
+                "BBB": [1] * 94,
+                "CCC": list(range(94, 0, -1)),
             },
             index=all_dates,
         )
@@ -36,6 +36,12 @@ class TestBacktestingEngine(unittest.TestCase):
     def test_buy_and_hold_return(self, mock_adapter):
         mock_adapter.side_effect = self.fake_adapter
         result = self.engine.BuyAndHoldReturn(["AAA", "BBB"])
+        self.assertGreater(result, 0)
+
+    @patch.object(MarketDataFetcher, "MarketDataAdapter")
+    def test_interval_backtest(self, mock_adapter):
+        mock_adapter.side_effect = self.fake_adapter
+        result = self.engine.IntervalBacktest(["AAA", "BBB", "CCC"], 1)
         self.assertGreater(result, 0)
 
 

--- a/main.py
+++ b/main.py
@@ -73,6 +73,10 @@ def main() -> None:
         hist_alloc = backtester.AllocationFromHistory(tickers)
         backtest_return = backtester.PortfolioBacktest(hist_alloc)
         baseline_return = backtester.BuyAndHoldReturn(tickers)
+        interval = config.get("RebalanceIntervalMonths")
+        if interval:
+            dynamic_return = backtester.IntervalBacktest(tickers, interval)
+            print(f"Interval Backtest return: {dynamic_return:.2%}")
         print(f"Backtest return: {backtest_return:.2%}")
         print(f"Buy and Hold return: {baseline_return:.2%}")
     except Exception as exc:


### PR DESCRIPTION
## Summary
- support computing allocations up to a custom date
- add interval-based portfolio backtest with rebalancing
- expose dynamic backtest in main using `RebalanceIntervalMonths` config
- include new config option
- test new backtest logic