### PR TITLE
Implement portfolio rebalancing

### DIFF
--- a/UnitTests/test_backtesting_engine.py
+++ b/UnitTests/test_backtesting_engine.py
@@ -29,7 +29,7 @@ class TestBacktestingEngine(unittest.TestCase):
         mock_adapter.side_effect = self.fake_adapter
         alloc = self.engine.AllocationFromHistory(["AAA", "BBB", "CCC"])
         self.assertListEqual(list(alloc.index), ["AAA"])
-        result = self.engine.PortfolioBacktest(alloc)
+        result = self.engine.PortfolioBacktest(alloc, rebalance_months=0)
         self.assertGreater(result, 0)
 
     @patch.object(MarketDataFetcher, "MarketDataAdapter")
@@ -42,6 +42,13 @@ class TestBacktestingEngine(unittest.TestCase):
     def test_interval_backtest(self, mock_adapter):
         mock_adapter.side_effect = self.fake_adapter
         result = self.engine.IntervalBacktest(["AAA", "BBB", "CCC"], 1)
+        self.assertGreater(result, 0)
+
+    @patch.object(MarketDataFetcher, "MarketDataAdapter")
+    def test_portfolio_backtest_rebalance(self, mock_adapter):
+        mock_adapter.side_effect = self.fake_adapter
+        alloc = self.engine.AllocationFromHistory(["AAA", "BBB", "CCC"])
+        result = self.engine.PortfolioBacktest(alloc, rebalance_months=1)
         self.assertGreater(result, 0)
 
 

--- a/main.py
+++ b/main.py
@@ -71,13 +71,13 @@ def main() -> None:
 
         backtester = BacktestingEngine(fetcher)
         hist_alloc = backtester.AllocationFromHistory(tickers)
-        backtest_return = backtester.PortfolioBacktest(hist_alloc)
+        interval = config.get("RebalanceIntervalMonths", 0)
+        backtest_return = backtester.PortfolioBacktest(hist_alloc, interval)
         baseline_return = backtester.BuyAndHoldReturn(tickers)
-        interval = config.get("RebalanceIntervalMonths")
         if interval:
-            dynamic_return = backtester.IntervalBacktest(tickers, interval)
-            print(f"Interval Backtest return: {dynamic_return:.2%}")
-        print(f"Backtest return: {backtest_return:.2%}")
+            print(f"Interval Backtest return: {backtest_return:.2%}")
+        else:
+            print(f"Backtest return: {backtest_return:.2%}")
         print(f"Buy and Hold return: {baseline_return:.2%}")
     except Exception as exc:
         print(f"Failed to fetch data: {exc}")


### PR DESCRIPTION
## Summary
- add period helper for running a single backtest
- allow `PortfolioBacktest` to rebalance monthly
- simplify `IntervalBacktest` to use `PortfolioBacktest`
- update CLI to use the new backtest logic
- extend unit tests for rebalancing logic